### PR TITLE
Cleanse `main.go` to finish debugging

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"os/exec"
 
 	"github.com/Rindrics/execute-script-with-merge/application"
 	"github.com/Rindrics/execute-script-with-merge/domain"
@@ -15,14 +13,6 @@ func main() {
 	logger := infrastructure.NewLogger()
 
 	logger.Info("starting application")
-
-	logger.Debug("main", "path", os.Getenv("PATH"))
-
-	echo, err := exec.Command("echo", "$PATH").Output()
-	fmt.Printf("echo:\n%s :Error:\n%v\n", echo, err)
-
-	git, err := exec.Command("git", "--version").Output()
-	fmt.Printf("git:\n%s :Error:\n%v\n", git, err)
 
 	logger.Debug("main", "event path", os.Getenv(domain.EnvVarGitHubEventPath))
 


### PR DESCRIPTION
Because `git` is now available by 2635ee6

This reverts commit ff7a2d65f61051198cc70160070c8e37849a2556.
